### PR TITLE
Fix multi_eval_ensemble.py

### DIFF
--- a/multi_eval_ensemble.py
+++ b/multi_eval_ensemble.py
@@ -97,7 +97,7 @@ else:
                             'cnn_model': opt.cnn_model})
 # When eval using provided pretrained model, the vocab may be different from what you have in your cocotalk.json
 # So make sure to use the vocab in infos file.
-loader.ix_to_word = infos['vocab']
+loader.dataset.ix_to_word = infos['vocab']
 
 #opt.id = '+'.join([_+str(__) for _,__ in zip(opt.ids, opt.weights)])
 # Set sample options


### PR DESCRIPTION
get_vocab() method of DataLoader class calls get_vocab() method of Dataset class. Hence, to change the vocabulary, we need to update ix_to_word of loader.dataset instead of loader.